### PR TITLE
Add hacky-patching target and make it easier to disable coreos-installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,12 @@
+#
+# You may override any of these variables on the command line e.g.
+#
+#  $> make generate COREOS_INSTALLER_ARGS=
+#
+# will cause coreos-installer not to be executed at the end of bootkube
+
+COREOS_INSTALLER_ARGS = /dev/vda
+RELEASE_IMAGE = "quay.io/eranco74/ocp-release:bootstrap-in-place"
 INSTALLER_BINDIR = ~/go/src/github.com/openshift/installer/bin
 
 clean: destroy
@@ -9,7 +18,7 @@ destroy:
 generate:
 	mkdir -p mydir
 	cp ./install-config.yaml mydir/
-	OPENSHIFT_INSTALL_EXPERIMENTAL_BOOTSTRAP_IN_PLACE=true OPENSHIFT_INSTALL_EXPERIMENTAL_BOOTSTRAP_IN_PLACE_COREOS_INSTALLER_ARGS=/dev/vda OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="quay.io/eranco74/ocp-release:bootstrap-in-place" $(INSTALLER_BINDIR)/openshift-install create ignition-configs --dir=mydir
+	OPENSHIFT_INSTALL_EXPERIMENTAL_BOOTSTRAP_IN_PLACE=true OPENSHIFT_INSTALL_EXPERIMENTAL_BOOTSTRAP_IN_PLACE_COREOS_INSTALLER_ARGS="$(COREOS_INSTALLER_ARGS)" OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="$(RELEASE_IMAGE)" $(INSTALLER_BINDIR)/openshift-install create ignition-configs --dir=mydir
 
 embed: download-iso
 	sudo podman run --pull=always --privileged --rm -v /dev:/dev -v /run/udev:/run/udev -v .:/data -w /data quay.io/coreos/coreos-installer:release iso ignition embed /data/installer-image.iso -f --ignition-file /data/mydir/bootstrap-in-place-for-live-iso.ign -o /data/installer-SNO-image.iso

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ destroy:
 generate:
 	mkdir -p mydir
 	cp ./install-config.yaml mydir/
-	OPENSHIFT_INSTALL_EXPERIMENTAL_BOOTSTRAP_IN_PLACE=true OPENSHIFT_INSTALL_EXPERIMENTAL_BOOTSTRAP_IN_PLACE_COREOS_INSTALLER_ARGS="$(COREOS_INSTALLER_ARGS)" OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="$(RELEASE_IMAGE)" $(INSTALLER_BINDIR)/openshift-install create ignition-configs --dir=mydir
+	OPENSHIFT_INSTALL_EXPERIMENTAL_BOOTSTRAP_IN_PLACE=true OPENSHIFT_INSTALL_EXPERIMENTAL_BOOTSTRAP_IN_PLACE_COREOS_INSTALLER_ARGS="$(COREOS_INSTALLER_ARGS)" OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="$(RELEASE_IMAGE)" $(INSTALLER_BINDIR)/openshift-install create single-node-ignition-config --dir=mydir
 
 embed: download-iso
 	sudo podman run --pull=always --privileged --rm -v /dev:/dev -v /run/udev:/run/udev -v .:/data -w /data quay.io/coreos/coreos-installer:release iso ignition embed /data/installer-image.iso -f --ignition-file /data/mydir/bootstrap-in-place-for-live-iso.ign -o /data/installer-SNO-image.iso

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@
 
 COREOS_INSTALLER_ARGS = /dev/vda
 RELEASE_IMAGE = "quay.io/eranco74/ocp-release:bootstrap-in-place"
-INSTALLER_BINDIR = ~/go/src/github.com/openshift/installer/bin
+INSTALLER_SRCDIR = ~/go/src/github.com/openshift/installer
+
+INSTALLER_BINDIR = $(INSTALLER_SRCDIR)/bin
 
 clean: destroy
 	rm -rf mydir
@@ -30,6 +32,11 @@ download-iso:
 
 start-iso:
 	./hack/virt-install-sno-iso-ign.sh
+
+patch:
+	cd $(INSTALLER_SRCDIR) && git am -3 $(CURDIR)/installer-patches/*.patch
+installer: patch
+	cd $(INSTALLER_SRCDIR) && hack/build.sh
 
 network:
 	./hack/virt-create-net.sh

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 See https://github.com/openshift/enhancements/pull/565
 
-First, build the modified installer:
+Check out the `bootstrap-in-place` installer branch:
 
 ```
 $> cd ~/go/src/github.com/openshift/installer
 $> git remote add -f eranco74 git@github.com:eranco74/installer.git
-$> git checkout -b bootstrap-in-place-poc eranco74/bootstrap-in-place-poc
-$> hack/build.sh
+$> git checkout -b bootstrap-in-place eranco74/bootstrap-in-place
 ```
 
-- Copy ./install-config.yaml.tmpl` to ./install-config.yaml` and add your ssh key and pull secret to it
+- Patch and build the installer - `make installer`
+- Copy `./install-config.yaml.tmpl` to ./install-config.yaml` and add your ssh key and pull secret to it
 - Generate ignition - `make generate`
 - Set up networking - `make network` (provides DNS for `Cluster name: test-cluster, Base DNS: redhat.com`)
 - Download rhcos image - `make embed` (download RHCOS liveCD and embed the bootstrap Ignition)

--- a/installer-patches/0001-Add-patch.service-as-a-temporary-hack.patch
+++ b/installer-patches/0001-Add-patch.service-as-a-temporary-hack.patch
@@ -1,0 +1,68 @@
+From 26731a3059430c638a796e2d0904df26e7bc9553 Mon Sep 17 00:00:00 2001
+From: Eran Cohen <ercohen@redhat.com>
+Date: Tue, 12 Jan 2021 14:44:00 +0000
+Subject: [PATCH] Add patch.service as a temporary hack
+
+The patch.service is the temporary hack we use to complete the single
+node installation. As such, it is not necessarily related to
+bootstrap-in-place.
+
+It will go away once cluster-etcd-operator and
+cluster-authentication-operator support single node deployments.
+
+Currently the service needs to run while cluster-bootstrap is running
+(control plane is up).
+
+We tried to move it to run after the reboot but noticed some race
+https://bugzilla.redhat.com/show_bug.cgi?id=1905221#c21.
+
+Since this is just for the POC and will be replaced by
+cluster-etcd-operator and cluster-authentication-operator changes, we
+have kept it in the bootstrap phase for now.
+---
+ .../bootstrap-in-place-post-reboot.sh                  | 10 ++++++++++
+ pkg/asset/ignition/bootstrap/bootstrap.go              |  1 +
+ 2 files changed, 11 insertions(+)
+
+diff --git a/data/data/bootstrap/bootstrap-in-place/opt/openshift/bootstrap-in-place/bootstrap-in-place-post-reboot.sh b/data/data/bootstrap/bootstrap-in-place/opt/openshift/bootstrap-in-place/bootstrap-in-place-post-reboot.sh
+index 407164a47..a95285d40 100755
+--- a/data/data/bootstrap/bootstrap-in-place/opt/openshift/bootstrap-in-place/bootstrap-in-place-post-reboot.sh
++++ b/data/data/bootstrap/bootstrap-in-place/opt/openshift/bootstrap-in-place/bootstrap-in-place-post-reboot.sh
+@@ -46,6 +46,15 @@ function approve_csr {
+   fi
+ }
+ 
++function patch_ingress {
++  echo "patch ingress operator to run a single router pod"
++  while ! oc patch -n openshift-ingress-operator ingresscontroller/default --patch '{"spec":{"replicas": 1}}' --type=merge;
++  do
++    echo "Still waiting to patch ingress ..."
++    sleep 3
++  done
++}
++
+ function wait_for_cvo {
+   echo "Waiting for cvo"
+   until [ "$(oc get clusterversion -o jsonpath='{.items[0].status.conditions[?(@.type=="Available")].status}')" == "True" ];
+@@ -64,5 +73,6 @@ function clean {
+ 
+ wait_for_api
+ approve_csr
++patch_ingress
+ wait_for_cvo
+ clean
+diff --git a/pkg/asset/ignition/bootstrap/bootstrap.go b/pkg/asset/ignition/bootstrap/bootstrap.go
+index 4e1e88985..f9f87f46e 100644
+--- a/pkg/asset/ignition/bootstrap/bootstrap.go
++++ b/pkg/asset/ignition/bootstrap/bootstrap.go
+@@ -366,6 +366,7 @@ func (a *Bootstrap) addSystemdUnits(uri string, templateData *bootstrapTemplateD
+ 		"chown-gatewayd-key.service":      {},
+ 		"systemd-journal-gatewayd.socket": {},
+ 		"approve-csr.service":             {},
++		"patch.service":             {},
+ 		// baremetal & openstack platform services
+ 		"keepalived.service":        {},
+ 		"coredns.service":           {},
+-- 
+2.27.0
+


### PR DESCRIPTION
Rather than including the temporary hacks for single-node clusters in the bootstrap-in-place-poc installer branch - which will then diverge from the bootstrap-in-place branch used for the openshift/installer#4482 PR - let's just do it with a Makefile target that patches and builds the installer.
