### PR TITLE
DNS fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 INSTALLER_BINDIR = ~/go/src/github.com/openshift/installer/bin
 
-clean: destroy
+clean: destroy network-destroy
 	rm -rf mydir
 
 destroy:
@@ -24,6 +24,9 @@ start-iso:
 
 network:
 	./hack/virt-create-net.sh
+
+network-destroy:
+	./hack/virt-destroy-net.sh || true
 
 ssh:
 	ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no core@192.168.126.10

--- a/hack/net.xml
+++ b/hack/net.xml
@@ -5,7 +5,7 @@
   <bridge name='tt0' stp='on' delay='0'/>
   <mtu size='1500'/>
   <mac address='52:54:00:e0:8d:fe'/>
-  <domain name='redhat.com' localOnly='yes'/>
+  <domain name='test-cluster.redhat.com' localOnly='yes'/>
   <dns enable='yes'>
     <host ip='192.168.126.10'>
       <hostname>api.test-cluster.redhat.com</hostname>

--- a/hack/virt-create-net.sh
+++ b/hack/virt-create-net.sh
@@ -4,4 +4,4 @@ sudo virsh net-create ./hack/net.xml
 
 echo server=/api.test-cluster.redhat.com/192.168.126.1 | sudo tee /etc/NetworkManager/dnsmasq.d/aio.conf
 echo -e "[main]\ndns=dnsmasq" | sudo tee /etc/NetworkManager/conf.d/aio.conf
-systemctl reload NetworkManager.service
+sudo systemctl reload NetworkManager.service

--- a/hack/virt-create-net.sh
+++ b/hack/virt-create-net.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+# Create a libvirt virtual network called 'test-net' configured
+# to assign master1.test-cluster.redhat.com/192.168.126.10 to
+# DHCP requests from 52:54:00:ee:42:e1
+# libvirt will also configure dnsmasq (listening on 192.168.126.1)
+# to respond to DNS queries for several hosts under
+# test-cluster.redhat.com with the 192.168.126.10 address.
+# This dnsmasq is also configured to not forward unresolved requests
+# within the test-cluster.redhat.com domain to upstream DNS servers.
+# Finally, we configure NetworkManager to send any DNS queries
+# on this machine for api.test-cluster.redhat.com to the libvirt
+# configured dnsmasq on 192.168.126.1
+
 sudo virsh net-create ./hack/net.xml
 
 echo server=/api.test-cluster.redhat.com/192.168.126.1 | sudo tee /etc/NetworkManager/dnsmasq.d/aio.conf

--- a/hack/virt-delete-sno.sh
+++ b/hack/virt-delete-sno.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
-sudo virsh destroy sno-test
-sudo virsh undefine sno-test
+VM_NAME=`awk -F'"' '/^VM_NAME/ {print $(NF-1)}' hack/virt-install-sno-iso-ign.sh`
+sudo virsh destroy $VM_NAME
+sudo virsh undefine $VM_NAME
+
+NET_NAME=`xmllint  --xpath 'string(//network/name)' hack/net.xml`
+sudo virsh net-destroy $NET_NAME
+sudo virsh net-undefine $NET_NAME
+
 sudo virsh vol-delete --pool default sno-test.qcow2

--- a/hack/virt-delete-sno.sh
+++ b/hack/virt-delete-sno.sh
@@ -3,8 +3,4 @@ VM_NAME=`awk -F'"' '/^VM_NAME/ {print $(NF-1)}' hack/virt-install-sno-iso-ign.sh
 sudo virsh destroy $VM_NAME
 sudo virsh undefine $VM_NAME
 
-NET_NAME=`xmllint  --xpath 'string(//network/name)' hack/net.xml`
-sudo virsh net-destroy $NET_NAME
-sudo virsh net-undefine $NET_NAME
-
 sudo virsh vol-delete --pool default sno-test.qcow2

--- a/hack/virt-destroy-net.sh
+++ b/hack/virt-destroy-net.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+sudo rm -f /etc/NetworkManager/conf.d/aio.conf /etc/NetworkManager/dnsmasq.d/aio.conf
+sudo systemctl reload NetworkManager.service
+
+NET_NAME=`xmllint  --xpath 'string(//network/name)' hack/net.xml`
+sudo virsh net-destroy $NET_NAME


### PR DESCRIPTION
I spent some time debugging DNS weirdness caused by entries in my /etc/hosts.

These changes should improve the DNS situation generally, but maybe the only significant change is to make the domain in hack/net.xml "test-cluster.redhat.com" instead of just "redhat.com". As explained in that commit ...

We want hosts in this network to be on the test-cluster.redhat.com domain, so it makes sense to do this. However, it also means that the 'localOnly' configuration only applies to names under this domain and queries for e.g. registry.connect.redhat.com will be forwarded to upstream DNS servers.
    
 i.e. before:

```    
$> host registry.connect.redhat.com 192.168.126.1
Using domain server:
Name: 192.168.126.1
Address: 192.168.126.1#53
Aliases:
   
Host registry.connect.redhat.com not found: 3(NXDOMAIN)
```
    
and after:

```
$> host registry.connect.redhat.com 192.168.126.1
Using domain server:
Name: 192.168.126.1
Address: 192.168.126.1#53
Aliases:
    
registry.connect.redhat.com is an alias for registry.connect.redhat.com2.edgekey.net.
registry.connect.redhat.com2.edgekey.net is an alias for registry.connect.redhat.com2.edgekey.net.globalredir.akadns.net.
registry.connect.redhat.com2.edgekey.net.globalredir.akadns.net is an alias for e40408.d.akamaiedge.net.
e40408.d.akamaiedge.net has address 23.75.23.179
e40408.d.akamaiedge.net has address 23.75.23.95
```