### PR TITLE
Make tabs not spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ $(INSTALLER_ISO_PATH):
 
 # Get the openshift-installer from the release image
 $(INSTALLER_BIN): registry-conifg.json
-       oc adm release extract --registry-config=registry-conifg.json --command=openshift-install --to ./bin $(RELEASE_IMAGE)
+	oc adm release extract --registry-config=registry-conifg.json --command=openshift-install --to ./bin $(RELEASE_IMAGE)
 
 registry-conifg.json:
 	jq -n '$(PULL_SECRET)' > registry-conifg.json


### PR DESCRIPTION
Took me way too long to figure out what's wrong.... the `:` in RELEASE_IMAGE made the Makefile think that 0.5.0 is a prerequisite for INSTALLER_BIN because spaces were used instead of tabs