### PR TITLE
make machine properties configurable

### DIFF
--- a/virt-install-sno-ign.sh
+++ b/virt-install-sno-ign.sh
@@ -12,8 +12,8 @@ sudo restorecon "${IGNITION_CONFIG}"
 RHCOS_IMAGE="/tmp/rhcos-46.82.202008181646-0-qemu.x86_64.qcow2"
 VM_NAME="sno-test"
 OS_VARIANT="rhel8.1"
-RAM_MB="16384"
-DISK_GB="20"
+RAM_MB="${RAM_MB:-16384}"
+DISK_GB="${DISK_GB:-20}"
 
 virt-install \
     --connect qemu:///system \

--- a/virt-install-sno-iso-ign.sh
+++ b/virt-install-sno-iso-ign.sh
@@ -20,9 +20,9 @@ if [ -z ${NET_NAME+x} ]; then
 fi
 
 OS_VARIANT="rhel8.1"
-RAM_MB="16384"
-DISK_GB="30"
-CPU_CORE="6"
+RAM_MB="${RAM_MB:-16384}"
+DISK_GB="${DISK_GB:-30}"
+CPU_CORE="${CPU_CORE:-6}"
 
 rm nohup.out
 nohup virt-install \


### PR DESCRIPTION
This patch changes fixed-value machine property variables to default-value variables that can be set through the callers environment.

We came across the need to change the disk size when our OpenShift SNO install started to have issues due to disk pressure. We have also encountered CPU pressure issues under certain workloads.