### PR TITLE
Update rhcos version to 4.9 rc.0

### DIFF
--- a/download_live_iso.sh
+++ b/download_live_iso.sh
@@ -1,4 +1,4 @@
-export BASE_OS_IMAGE=${BASE_OS_IMAGE:-https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.0/rhcos-4.7.0-x86_64-live.x86_64.iso}
+export BASE_OS_IMAGE=${BASE_OS_IMAGE:-https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/latest-4.9/rhcos-4.9.0-rc.0-x86_64-live.x86_64.iso}
 
 if [ $# -eq 0 ]; then
     echo "USAGE: $0 download_path"


### PR DESCRIPTION
Testing 4.9 noticed that the rhcos version is too old .
