### PR TITLE
Bug-2004290: Updated download_live_iso.sh to use 4.9.0-rc.0 link instead of latest-4.9

### DIFF
--- a/download_live_iso.sh
+++ b/download_live_iso.sh
@@ -1,4 +1,4 @@
-export BASE_OS_IMAGE=${BASE_OS_IMAGE:-https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/latest-4.9/rhcos-4.9.0-rc.0-x86_64-live.x86_64.iso}
+export BASE_OS_IMAGE=${BASE_OS_IMAGE:-https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.9.0-rc.0/rhcos-live.x86_64.iso}
 
 if [ $# -eq 0 ]; then
     echo "USAGE: $0 download_path"


### PR DESCRIPTION
The latest-4.9 link now points to a diffeten rc and will keep getting
updates that will break the hard coded link in the script