### PR TITLE
Allowing downloading moved files.

### DIFF
--- a/download_live_iso.sh
+++ b/download_live_iso.sh
@@ -6,4 +6,4 @@ if [ $# -eq 0 ]; then
 fi
 
 DOWNLOAD_PATH=$1
-curl "${BASE_OS_IMAGE}" --retry 5 -o "${DOWNLOAD_PATH}"
+curl -L "${BASE_OS_IMAGE}" --retry 5 -o "${DOWNLOAD_PATH}"


### PR DESCRIPTION
The official documentation shows a dynamically generated
URL. Curling this URL requires the '-L' arg.

Signed-off-by: Alexander Chuzhoy <achuzhoy@redhat.com>