### PR TITLE
Switch to OVNKubernetes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ifndef PULL_SECRET
 endif
 
 INSTALLATION_DISK ?= /dev/vda
-RELEASE_IMAGE ?= quay.io/openshift-release-dev/ocp-release:4.10.6-x86_64
+RELEASE_IMAGE ?= quay.io/openshift-release-dev/ocp-release:4.11.5-x86_64
 
 ########################
 

--- a/download_live_iso.sh
+++ b/download_live_iso.sh
@@ -1,4 +1,4 @@
-export BASE_OS_IMAGE=${BASE_OS_IMAGE:-https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.0/rhcos-4.9.0-x86_64-live.x86_64.iso}
+export BASE_OS_IMAGE=${BASE_OS_IMAGE:-https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.11/4.11.2/rhcos-4.11.2-x86_64-live.x86_64.iso}
 
 if [ $# -eq 0 ]; then
     echo "USAGE: $0 download_path"

--- a/install-config.yaml.template
+++ b/install-config.yaml.template
@@ -21,7 +21,7 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: MACHINE_NETWORK
-  networkType: OpenShiftSDN
+  networkType: OVNKubernetes
   serviceNetwork:
   - CLUSTER_SVC_NETWORK
 platform:


### PR DESCRIPTION
Since OCP 4.10, OpenShiftSDN is no longer supported on SNO. Switch to OVNKubernetes.

Other changes:
  - bump to the latest available 4.11 life ISO base image
  - bump the RELEASE_IMAGE