### PR TITLE
Add support in Agent Based Installation (ABI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ Automatic mode using Makefiles, currently supports SNO deployments on two virtua
     - Create a VM in vSphere
     - Boot the VM with that ISO
 
+
+# Install SNO with bootstrap in place using the `Agent Based Installer (ABI)` flow
+- Set PULL_SECRET environment variable to your pull secret
+- `make start-iso-abi` - Spins up a VM with the ABI ISO. This will automatically perform the following actions:
+    - Extract the openshift installer from the release image.
+    - Generate the install-config.yaml.
+    - Execute the openshift-installer `agent create image` command to generate the agent.iso.
+    - Create a libvirt network & VM.
+    - Boot the VM with that ISO.
+- You can now monitor the progress using `make ssh` and `journalctl -f -u assisted-service.service` or `kubectl --kubeconfig ./sno-workdir/auth/kubeconfig get clusterversion`.
+
 # Other notes
 
 * Default release image is quay.io/openshift-release-dev/ocp-release:4.13.0-x86_64 you can override it using RELEASE_IMAGE env var.

--- a/agent-config.yaml
+++ b/agent-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1alpha1
+kind: AgentConfig
+metadata:
+  name: sno-cluster
+rendezvousIP: 192.168.126.10
+

--- a/create-abi-image.sh
+++ b/create-abi-image.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+if [ -z ${RELEASE_IMAGE+x} ]; then
+	echo "Please set RELEASE_IMAGE"
+	exit 1
+fi
+
+if [ -z ${INSTALLER_BIN+x} ]; then
+	echo "Please set INSTALLER_BIN"
+	exit 1
+fi
+
+if [ -z ${INSTALLER_WORKDIR+x} ]; then
+	echo "Please set INSTALLER_WORKDIR"
+	exit 1
+fi
+
+OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="${RELEASE_IMAGE}" \
+${INSTALLER_BIN} agent create image --log-level debug --dir="${INSTALLER_WORKDIR}"

--- a/virt-install-sno-iso-ign.sh
+++ b/virt-install-sno-iso-ign.sh
@@ -24,7 +24,7 @@ RAM_MB="${RAM_MB:-16384}"
 DISK_GB="${DISK_GB:-30}"
 CPU_CORE="${CPU_CORE:-6}"
 
-rm nohup.out
+rm -f nohup.out
 nohup virt-install \
     --connect qemu:///system \
     -n "${VM_NAME}" \
@@ -37,6 +37,7 @@ nohup virt-install \
     --events on_reboot=restart \
     --cdrom "${RHCOS_ISO}" \
     --disk pool=default,size="${DISK_GB}" \
+    --check disk_size=off \
     --boot hd,cdrom \
     --noautoconsole \
     --wait=-1 &


### PR DESCRIPTION
Run make start-iso-abi to start a VM with ABI based ISO that installs SNO